### PR TITLE
Change 'simplejson' import statement to 'json'

### DIFF
--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -12,7 +12,7 @@ from time import time
 from struct import pack, unpack
 from collections import namedtuple
 
-import simplejson as json
+import json
 from pbkdf2 import PBKDF2
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -345,7 +345,7 @@ class EncryptedPickle(object):
         '''Encode data with specific algorithm'''
 
         if algorithm['type'] == 'hmac':
-            return data + self._hmac_generate(data, algorithm, key)
+            return str(data) + self._hmac_generate(data, algorithm, key)
         elif algorithm['type'] == 'aes':
             return self._aes_encrypt(data, algorithm, key)
         elif algorithm['type'] == 'no-serialization':

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -561,8 +561,8 @@ class EncryptedPickle(object):
         '''Add magic'''
 
         if self.magic:
-            return self.magic + data
-
+            return self.magic + data.decode("utf-8")
+        
         return data
 
     def _add_header(self, data, options):

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -345,7 +345,7 @@ class EncryptedPickle(object):
         '''Encode data with specific algorithm'''
 
         if algorithm['type'] == 'hmac':
-            return str(data) + self._hmac_generate(data, algorithm, key)
+            return data + str(self._hmac_generate(data, algorithm, key))
         elif algorithm['type'] == 'aes':
             return self._aes_encrypt(data, algorithm, key)
         elif algorithm['type'] == 'no-serialization':

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -561,7 +561,7 @@ class EncryptedPickle(object):
         '''Add magic'''
 
         if self.magic:
-            return self.magic + data.decode("utf-8")
+            return self.magic + data.decode('utf-8')
         
         return data
 

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -749,7 +749,7 @@ class EncryptedPickle(object):
         numpad = block_size - (len(data) % block_size)
         data = data + numpad * chr(numpad)
 
-        enc = AES.new(key, mode, iv_value).encrypt(data)
+        enc = AES.new(key, mode, iv_value).encrypt(data.encode('utf-8'))
 
         if include_iv:
             enc = iv_value + enc

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -14,9 +14,9 @@ from collections import namedtuple
 
 import json
 from pbkdf2 import PBKDF2
-from Crypto.Cipher import AES
-from Crypto.Random import get_random_bytes
-from Crypto.Hash import HMAC, SHA, SHA256, SHA384, SHA512
+from Cryptodome.Cipher import AES
+from Cryptodome.Random import get_random_bytes
+from Cryptodome.Hash import HMAC, SHA, SHA256, SHA384, SHA512
 
 from .utils import (
     const_equal,

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -575,7 +575,7 @@ class EncryptedPickle(object):
         flags = options['flags']
 
         header_flags = dict(
-            (i, str(int(j))) for i, j in options['flags'].iteritems())
+            (i, str(int(j))) for i, j in options['flags'].items())
         header_flags = ''.join(version_info['flags'](**header_flags))
         header_flags = int(header_flags, 2)
         options['flags'] = header_flags

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -722,7 +722,7 @@ class EncryptedPickle(object):
 
         digestmod = EncryptedPickle._get_hashlib(algorithm['subtype'])
 
-        return HMAC.new(key, data, digestmod).digest()
+        return HMAC.new(key, data.encode('utf-8'), digestmod).digest()
 
     @staticmethod
     def _aes_encrypt(data, algorithm, key):

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -561,7 +561,7 @@ class EncryptedPickle(object):
         '''Add magic'''
 
         if self.magic:
-            return self.magic + data.decode('utf-8')
+            return self.magic + data.decode('utf-8').strip()
         
         return data
 

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -561,7 +561,7 @@ class EncryptedPickle(object):
         '''Add magic'''
 
         if self.magic:
-            return self.magic + data.decode('utf-8').strip()
+            return self.magic + str(data)
         
         return data
 

--- a/encryptedpickle/encryptedpickle.py
+++ b/encryptedpickle/encryptedpickle.py
@@ -400,7 +400,7 @@ class EncryptedPickle(object):
 
         data = self._encode(data, algorithm, key)
 
-        return data + key_salt
+        return data + str(key_salt)
 
     def _unsign_data(self, data, options):
         '''Verify and remove signature'''

--- a/encryptedpickle/utils.py
+++ b/encryptedpickle/utils.py
@@ -7,11 +7,13 @@ Some common, generic utilities
 from __future__ import absolute_import
 
 from base64 import urlsafe_b64encode, urlsafe_b64decode
+import warnings
 
 
 def urlsafe_nopadding_b64encode(data):
     '''URL safe Base64 encode without padding (=)'''
-
+    
+    warnings.warn(data)
     return urlsafe_b64encode(data.encode('utf-8')).rstrip('=')
 
 def urlsafe_nopadding_b64decode(data):

--- a/encryptedpickle/utils.py
+++ b/encryptedpickle/utils.py
@@ -12,7 +12,7 @@ from base64 import urlsafe_b64encode, urlsafe_b64decode
 def urlsafe_nopadding_b64encode(data):
     '''URL safe Base64 encode without padding (=)'''
 
-    return urlsafe_b64encode(data).rstrip('=')
+    return urlsafe_b64encode(data.encode('utf-8')).rstrip('=')
 
 def urlsafe_nopadding_b64decode(data):
     '''URL safe Base64 decode without padding (=)'''
@@ -22,7 +22,7 @@ def urlsafe_nopadding_b64decode(data):
         padding = 4 - padding
     padding = '=' * padding
     data = data + padding
-    return urlsafe_b64decode(data)
+    return urlsafe_b64decode(data.encode('utf-8'))
 
 def const_equal(str_a, str_b):
     '''Constant time string comparison'''

--- a/encryptedpickle/utils.py
+++ b/encryptedpickle/utils.py
@@ -12,7 +12,7 @@ from base64 import urlsafe_b64encode, urlsafe_b64decode
 def urlsafe_nopadding_b64encode(data):
     '''URL safe Base64 encode without padding (=)'''
 
-    return urlsafe_b64encode(data).rstrip('=')
+    return urlsafe_b64encode(data.encode('utf-8')).rstrip('=')
 
 def urlsafe_nopadding_b64decode(data):
     '''URL safe Base64 decode without padding (=)'''
@@ -22,7 +22,7 @@ def urlsafe_nopadding_b64decode(data):
         padding = 4 - padding
     padding = '=' * padding
     data = data + padding
-    return urlsafe_b64decode(data.encode('utf-8'))
+    return urlsafe_b64decode(data)
 
 def const_equal(str_a, str_b):
     '''Constant time string comparison'''

--- a/encryptedpickle/utils.py
+++ b/encryptedpickle/utils.py
@@ -12,7 +12,7 @@ from base64 import urlsafe_b64encode, urlsafe_b64decode
 def urlsafe_nopadding_b64encode(data):
     '''URL safe Base64 encode without padding (=)'''
 
-    return urlsafe_b64encode(data.encode('utf-8')).rstrip('=')
+    return urlsafe_b64encode(data).rstrip('=')
 
 def urlsafe_nopadding_b64decode(data):
     '''URL safe Base64 decode without padding (=)'''

--- a/encryptedpickle/utils.py
+++ b/encryptedpickle/utils.py
@@ -13,7 +13,7 @@ import warnings
 def urlsafe_nopadding_b64encode(data):
     '''URL safe Base64 encode without padding (=)'''
     
-    warnings.warn(data)
+    warnings.warn(type(data))
     return urlsafe_b64encode(data.encode('utf-8')).rstrip('=')
 
 def urlsafe_nopadding_b64decode(data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pbkdf2>=1.3
-pycryptodome>=3.9.8
+pycryptodomex>=3.9.8
 simplejson

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pbkdf2>=1.3
-pycrypto>=2.6
+pycryptodome>=3.9.8
 simplejson


### PR DESCRIPTION
simplejson has been renamed to json in versions of python 2.6 and up, and is therefore no longer compatible and will return a ModuleNotFoundError on install because of this.